### PR TITLE
Travis CI: Download the WildFly nightly builds from TeamCity instead of Jenkins (which is currently disabled)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ jdk:
 install: echo LOL
 
 script:
-    - wget https://ci.jboss.org/hudson/job/WildFly-latest-master/lastBuild/artifact/dist/target/wildfly-10.x.zip
-    - mvn install:install-file -DgroupId=org.wildfly -DartifactId=wildfly-dist -Dversion=11.0.0.elytron-SNAPSHOT -Dfile=wildfly-10.x.zip -DgeneratePom=true -Dpackaging=zip
+    - wget --user=guest --password=guest https://ci.wildfly.org/httpAuth/repository/downloadAll/WF_Nightly/.lastSuccessful/artifacts.zip
+    - unzip -q artifacts.zip
+    - export WILDFLY_DIST_ZIP=$(ls wildfly-*-SNAPSHOT.zip)
+    - mvn install:install-file -DgroupId=org.wildfly -DartifactId=wildfly-dist -Dversion=11.0.0.elytron-SNAPSHOT -Dfile=$WILDFLY_DIST_ZIP -DgeneratePom=true -Dpackaging=zip
     - mvn verify -s settings.xml -B -fae -Dmaven.test.redirectTestOutputToFile=true -Dtest=**.elytron.**.* -Dversion.wildfly10=11.0.0.elytron-SNAPSHOT


### PR DESCRIPTION
Just first try... not sure how the Travis handles wildcards.